### PR TITLE
Add Stage 1 serial sbatch scripts for parallel case initialization

### DIFF
--- a/runSweepHamilton-serial.sbatch
+++ b/runSweepHamilton-serial.sbatch
@@ -1,39 +1,32 @@
 #!/bin/bash
-#SBATCH --job-name=bubbleCoalescence
+#SBATCH --job-name=bubbleCoal-S1
 #SBATCH -N 1
-#SBATCH -n 128
+#SBATCH -n 48
 #SBATCH -c 1
-#SBATCH --mem=240G
-#SBATCH --time=3-00:00:00
-#SBATCH --gres=tmp:100G
+#SBATCH --mem=64G
+#SBATCH --time=12:00:00
 #SBATCH -p multi
 #SBATCH --mail-type=END,FAIL
 #SBATCH --mail-user=vatsal.sanjay@durham.ac.uk
-#SBATCH --output=slurm-%j.out
-#SBATCH --error=slurm-%j.err
+#SBATCH --output=slurm-stage1-%j.out
+#SBATCH --error=slurm-stage1-%j.err
 
 # ============================================================
-# Bubble Coalescence - HPC Parameter Sweep Runner (Hamilton)
+# Bubble Coalescence - Stage 1 Serial Runner (Hamilton)
 # ============================================================
-# This script runs Stage 2 (MPI simulation) on Durham University's Hamilton HPC.
+# This script runs Stage 1 (initialization) for all cases in parallel.
+# Each case runs on 1 core (serial, no OpenMP/MPI).
+# Up to 48 cases run simultaneously.
 #
-# PREREQUISITE: Restart files must already exist for each case.
-# Run Stage 1 locally before submitting:
-#   ./runParameterSweep.sh --stage1-only sweep.params
+# Stage 1 generates restart files needed for Stage 2 (MPI simulation).
 #
-# BEFORE RUNNING:
-# 1. Run Stage 1 locally to generate restart files for all cases
-# 2. Clone repo to /nobackup/$USER/ (NOT home directory)
-# 3. Run reset_install_requirements-no-darcs.sh to install Basilisk
-# 4. Edit sweep.params to set parameter ranges and case numbers
-# 5. Update --mail-user above with your Durham email
-# 6. Submit with: sbatch runSweepHamilton.sbatch
+# AFTER RUNNING:
+# Submit Stage 2 with: sbatch runSweepHamilton.sbatch
 #
 # SBATCH Parameters (Hamilton-specific):
-#   -n 128: Number of MPI tasks (whole node = 128 cores)
-#   --mem=240G: Memory per node (max 250G on standard nodes)
-#   --time=3-00:00:00: Max wall time (3 days for multi partition)
-#   --gres=tmp:100G: Temporary disk space ($TMPDIR)
+#   -n 48: Number of tasks (one per case, max 48 concurrent)
+#   --mem=64G: Memory (Stage 1 is less memory-intensive)
+#   --time=12:00:00: Wall time (Stage 1 is quick per case)
 #   -p multi: Partition for whole-node jobs
 # ============================================================
 
@@ -42,12 +35,14 @@ set -e  # Exit on error (but we'll handle case failures gracefully)
 # ============================================================
 # Configuration
 # ============================================================
-# Use SLURM_SUBMIT_DIR (directory where sbatch was called) as the project root
 SCRIPT_DIR="${SLURM_SUBMIT_DIR}"
 SWEEP_FILE="${SCRIPT_DIR}/sweep.params"
 
-# Number of MPI tasks for Stage 2
-MPI_TASKS=${SLURM_NTASKS:-128}
+# Maximum concurrent jobs (matches SLURM allocation)
+MAX_CONCURRENT=${SLURM_NTASKS:-48}
+
+# Stage 1 tmax - short run to generate restart file
+STAGE1_TMAX="1e-2"
 
 # ============================================================
 # Validate Working Directory
@@ -63,27 +58,27 @@ fi
 # Print Job Information
 # ============================================================
 echo "============================================="
-echo "Bubble Coalescence - HPC Parameter Sweep"
+echo "Bubble Coalescence - Stage 1 (Serial)"
 echo "============================================="
 echo "Job started at: $(date)"
 echo "Running on node: $(hostname)"
 echo "Working directory: $(pwd)"
 echo "Job ID: ${SLURM_JOB_ID}"
-echo "Number of MPI tasks: ${MPI_TASKS}"
+echo "Max concurrent cases: ${MAX_CONCURRENT}"
 echo "Partition: ${SLURM_JOB_PARTITION}"
-echo "Memory allocated: ${SLURM_MEM_PER_NODE}MB"
 echo ""
-echo "Mode: Stage 2 only (MPI simulation)"
-echo "      Restart files must exist for each case"
+echo "Mode: Stage 1 only (serial initialization)"
+echo "      Generates restart files for Stage 2"
+echo "      Each case runs on 1 core (no OpenMP/MPI)"
 echo ""
 
 # ============================================================
-# Load Required Modules
+# Load Required Modules (minimal for serial)
 # ============================================================
 echo "Loading modules..."
 module purge
-module load openmpi
-echo "Modules loaded successfully"
+# No MPI needed for serial execution
+echo "Modules loaded (serial mode - no MPI)"
 echo ""
 
 # ============================================================
@@ -104,7 +99,6 @@ echo ""
 # ============================================================
 # Validate Environment
 # ============================================================
-# Source parameter parsing library
 if [ -f "${SCRIPT_DIR}/src-local/parse_params.sh" ]; then
     source "${SCRIPT_DIR}/src-local/parse_params.sh"
 else
@@ -112,7 +106,6 @@ else
     exit 1
 fi
 
-# Check sweep file exists
 if [ ! -f "$SWEEP_FILE" ]; then
     echo "ERROR: Sweep file not found: $SWEEP_FILE" >&2
     exit 1
@@ -126,10 +119,8 @@ echo ""
 # ============================================================
 echo "Parsing sweep configuration..."
 
-# Source the sweep file to get variables
 source "$SWEEP_FILE"
 
-# Validate required variables
 if [ -z "$BASE_CONFIG" ]; then
     echo "ERROR: BASE_CONFIG not defined in sweep file" >&2
     exit 1
@@ -140,7 +131,6 @@ if [ -z "$CASE_START" ] || [ -z "$CASE_END" ]; then
     exit 1
 fi
 
-# Validate CaseNo range
 if [ "$CASE_START" -lt 1000 ] || [ "$CASE_START" -gt 9999 ]; then
     echo "ERROR: CASE_START must be 4-digit (1000-9999), got: $CASE_START" >&2
     exit 1
@@ -166,18 +156,13 @@ echo ""
 SWEEP_VARS=()
 SWEEP_VALUES=()
 
-# Read sweep file and extract SWEEP_* variables
 while IFS='=' read -r key value; do
-    # Skip comments and empty lines
     [[ "$key" =~ ^[[:space:]]*# ]] && continue
     [[ -z "$key" ]] && continue
 
-    # Match SWEEP_* variables
     if [[ "$key" =~ ^[[:space:]]*SWEEP_([^=]+) ]]; then
         var_name="${BASH_REMATCH[1]}"
-        # Remove inline comments and whitespace
         value=$(echo "$value" | sed 's/#.*//' | xargs)
-
         SWEEP_VARS+=("$var_name")
         SWEEP_VALUES+=("$value")
     fi
@@ -199,8 +184,6 @@ echo ""
 # ============================================================
 echo "Generating parameter combinations..."
 
-# Create temporary directory for generated parameter files
-# Use work directory, not /tmp (node-local on Hamilton)
 TEMP_DIR="${SCRIPT_DIR}/.sweep_tmp_$$"
 mkdir -p "$TEMP_DIR" || {
     echo "ERROR: Failed to create temp directory: $TEMP_DIR" >&2
@@ -212,20 +195,15 @@ CASE_NUM=$CASE_START
 COMBINATION_COUNT=0
 CASE_FILES=()
 
-# Recursive function to generate all combinations
 generate_combinations() {
     local depth=$1
     shift
     local current_values=("$@")
 
     if [ $depth -eq ${#SWEEP_VARS[@]} ]; then
-        # Base case: all variables assigned, create parameter file
         local case_file="${TEMP_DIR}/case_$(printf "%04d" $CASE_NUM).params"
-
-        # Copy base config
         cp "$BASE_CONFIG" "$case_file"
 
-        # Override CaseNo
         if grep -q "^CaseNo=" "$case_file"; then
             sed -i'.bak' "s|^CaseNo=.*|CaseNo=${CASE_NUM}|" "$case_file"
         else
@@ -233,7 +211,6 @@ generate_combinations() {
         fi
         rm -f "${case_file}.bak"
 
-        # Override with sweep values
         for i in "${!SWEEP_VARS[@]}"; do
             local var="${SWEEP_VARS[$i]}"
             local val="${current_values[$i]}"
@@ -249,7 +226,6 @@ generate_combinations() {
         CASE_FILES+=("$case_file")
         ((COMBINATION_COUNT++)) || true
 
-        # Print summary
         echo "Case $CASE_NUM:"
         for i in "${!SWEEP_VARS[@]}"; do
             echo "  ${SWEEP_VARS[$i]} = ${current_values[$i]}"
@@ -260,26 +236,22 @@ generate_combinations() {
         return
     fi
 
-    # Recursive case: iterate through values for current variable
     local values="${SWEEP_VALUES[$depth]}"
     IFS=',' read -ra value_array <<< "$values"
 
     for val in "${value_array[@]}"; do
-        val=$(echo "$val" | xargs)  # Trim whitespace
-        generate_combinations $((depth + 1)) ${current_values[@]+\"${current_values[@]}\"} "$val"
+        val=$(echo "$val" | xargs)
+        generate_combinations $((depth + 1)) ${current_values[@]+"${current_values[@]}"} "$val"
     done
 }
 
-# Start recursion
 generate_combinations 0
 
 echo "Generated $COMBINATION_COUNT parameter combinations"
 
-# Check if number of combinations matches the range
 EXPECTED_COUNT=$((CASE_END - CASE_START + 1))
 if [ $COMBINATION_COUNT -ne $EXPECTED_COUNT ]; then
     echo "WARNING: Generated $COMBINATION_COUNT combinations, but CASE_END suggests $EXPECTED_COUNT" >&2
-    echo "         Consider adjusting CASE_END in sweep file" >&2
 fi
 
 if [ $COMBINATION_COUNT -gt $EXPECTED_COUNT ]; then
@@ -290,144 +262,182 @@ fi
 echo ""
 
 # ============================================================
-# Run Simulations (Stage 2 Only - MPI)
+# Prepare Status Tracking
 # ============================================================
-echo "============================================="
-echo "Running $COMBINATION_COUNT Simulations"
-echo "============================================="
-echo "Stage 2 only: MPI simulation (${MPI_TASKS} tasks)"
-echo "Requires existing restart files in each case directory"
-echo ""
+STATUS_DIR="${TEMP_DIR}/status"
+mkdir -p "$STATUS_DIR"
 
-# Counters for tracking
-SUCCESSFUL_CASES=0
-FAILED_CASES=0
-SKIPPED_CASES=0
+# ============================================================
+# Function to Run Single Case (Stage 1)
+# ============================================================
+run_stage1_case() {
+    local param_file=$1
+    local status_dir=$2
+    local script_dir=$3
+    local stage1_tmax=$4
 
-for param_file in "${CASE_FILES[@]}"; do
-    # Parse parameter file to get values
+    # Source parameter parsing in subshell
+    source "${script_dir}/src-local/parse_params.sh"
+
     parse_param_file "$param_file"
-    CASE_NO=$(get_param "CaseNo")
-    OhOut=$(get_param "OhOut" "1e-2")
-    RhoIn=$(get_param "RhoIn" "1e-3")
-    Rr=$(get_param "Rr" "1.0")
-    MAXlevel=$(get_param "MAXlevel" "10")
-    tmax=$(get_param "tmax" "40.0")
-    zWall=$(get_param "zWall" "0.01")
+    local CASE_NO=$(get_param "CaseNo")
+    local OhOut=$(get_param "OhOut" "1e-2")
+    local RhoIn=$(get_param "RhoIn" "1e-3")
+    local Rr=$(get_param "Rr" "1.0")
+    local MAXlevel=$(get_param "MAXlevel" "10")
+    local zWall=$(get_param "zWall" "0.01")
 
     if [ -z "$CASE_NO" ]; then
-        echo "ERROR: CaseNo not found in $param_file" >&2
-        ((FAILED_CASES++)) || true
-        continue
+        echo "FAILED" > "${status_dir}/${CASE_NO:-unknown}"
+        return 1
     fi
 
-    CASE_DIR="${SCRIPT_DIR}/simulationCases/${CASE_NO}"
+    local CASE_DIR="${script_dir}/simulationCases/${CASE_NO}"
+    local LOG_FILE="${CASE_DIR}/stage1.log"
 
-    echo "========================================="
-    echo "Case $CASE_NO ($(date))"
-    echo "========================================="
-    echo "Parameters: OhOut=$OhOut, RhoIn=$RhoIn, Rr=$Rr"
-    echo "            MAXlevel=$MAXlevel, tmax=$tmax, zWall=$zWall"
+    {
+        echo "========================================="
+        echo "Case $CASE_NO - Stage 1 ($(date))"
+        echo "========================================="
+        echo "Parameters: OhOut=$OhOut, RhoIn=$RhoIn, Rr=$Rr"
+        echo "            MAXlevel=$MAXlevel, tmax=$stage1_tmax, zWall=$zWall"
 
-    # Check if case directory exists
-    if [ ! -d "$CASE_DIR" ]; then
-        echo "ERROR: Case directory not found: $CASE_DIR" >&2
-        echo "       Run Stage 1 locally first" >&2
-        ((SKIPPED_CASES++)) || true
-        continue
+        # Create case directory
+        mkdir -p "$CASE_DIR"
+        cd "$CASE_DIR"
+
+        # Copy source file
+        local SRC_FILE_ORIG="${script_dir}/simulationCases/coalescenceBubble.c"
+        if [ ! -f "$SRC_FILE_ORIG" ]; then
+            echo "ERROR: Source file not found"
+            echo "FAILED" > "${status_dir}/${CASE_NO}"
+            return 1
+        fi
+        cp "$SRC_FILE_ORIG" "coalescenceBubble.c"
+
+        # Create symlink to DataFiles
+        if [ ! -e "DataFiles" ]; then
+            ln -s ../DataFiles DataFiles
+        fi
+
+        # Compile SERIAL (no OpenMP, no MPI)
+        echo "Compiling (serial)..."
+        if ! qcc -I../../src-local -Wall -O2 -disable-dimensions \
+            coalescenceBubble.c -o coalescenceBubble -lm 2>&1; then
+            echo "ERROR: Compilation failed"
+            echo "FAILED" > "${status_dir}/${CASE_NO}"
+            return 1
+        fi
+        echo "Compilation successful"
+
+        # Run Stage 1 with small tmax
+        echo "Running Stage 1 (tmax=$stage1_tmax)..."
+        if ./coalescenceBubble $OhOut $RhoIn $Rr $MAXlevel $stage1_tmax $zWall; then
+            echo "Stage 1 completed"
+
+            # Verify restart file was created
+            if [ -f "restart" ]; then
+                echo "Restart file created successfully"
+                echo "SUCCESS" > "${status_dir}/${CASE_NO}"
+            else
+                echo "WARNING: restart file not found after Stage 1"
+                echo "FAILED" > "${status_dir}/${CASE_NO}"
+                return 1
+            fi
+        else
+            echo "ERROR: Stage 1 failed"
+            echo "FAILED" > "${status_dir}/${CASE_NO}"
+            return 1
+        fi
+
+        echo "Case $CASE_NO Stage 1 complete"
+    } > "$LOG_FILE" 2>&1
+
+    return 0
+}
+
+export -f run_stage1_case
+
+# ============================================================
+# Run All Cases in Parallel (Stage 1)
+# ============================================================
+echo "============================================="
+echo "Running $COMBINATION_COUNT Cases (Stage 1)"
+echo "============================================="
+echo "Max concurrent: ${MAX_CONCURRENT}"
+echo "Each case: serial execution, tmax=${STAGE1_TMAX}"
+echo ""
+
+RUNNING_JOBS=0
+PIDS=()
+
+for param_file in "${CASE_FILES[@]}"; do
+    # Wait if we've hit the concurrency limit
+    while [ $RUNNING_JOBS -ge $MAX_CONCURRENT ]; do
+        # Wait for any background job to finish
+        wait -n 2>/dev/null || true
+        ((RUNNING_JOBS--)) || true
+    done
+
+    # Launch case in background
+    run_stage1_case "$param_file" "$STATUS_DIR" "$SCRIPT_DIR" "$STAGE1_TMAX" &
+    PIDS+=($!)
+    ((RUNNING_JOBS++)) || true
+
+    # Extract case number for logging
+    parse_param_file "$param_file"
+    CASE_NO=$(get_param "CaseNo")
+    echo "Launched case $CASE_NO (PID: ${PIDS[-1]}, running: $RUNNING_JOBS)"
+done
+
+echo ""
+echo "All cases launched, waiting for completion..."
+echo ""
+
+# Wait for all remaining jobs
+wait
+
+# ============================================================
+# Collect Results
+# ============================================================
+SUCCESSFUL_CASES=0
+FAILED_CASES=0
+
+for status_file in "${STATUS_DIR}"/*; do
+    if [ -f "$status_file" ]; then
+        status=$(cat "$status_file")
+        case_no=$(basename "$status_file")
+        if [ "$status" = "SUCCESS" ]; then
+            ((SUCCESSFUL_CASES++)) || true
+        else
+            ((FAILED_CASES++)) || true
+            echo "FAILED: Case $case_no"
+        fi
     fi
-
-    # Change to case directory
-    cd "$CASE_DIR"
-
-    # Check for restart file (CRITICAL)
-    if [ ! -f "restart" ]; then
-        echo "ERROR: restart file not found for case $CASE_NO" >&2
-        echo "       Run Stage 1 locally first:" >&2
-        echo "       ./runSimulation.sh --stage1 <params_file>" >&2
-        ((SKIPPED_CASES++)) || true
-        cd "$SCRIPT_DIR"
-        continue
-    fi
-
-    echo "Found restart file"
-
-    # Copy source file to case directory if needed
-    SRC_FILE_ORIG="${SCRIPT_DIR}/simulationCases/coalescenceBubble.c"
-    SRC_FILE_LOCAL="$CASE_DIR/coalescenceBubble.c"
-
-    if [ ! -f "$SRC_FILE_ORIG" ]; then
-        echo "ERROR: Source file $SRC_FILE_ORIG not found" >&2
-        ((FAILED_CASES++)) || true
-        cd "$SCRIPT_DIR"
-        continue
-    fi
-
-    cp "$SRC_FILE_ORIG" "$SRC_FILE_LOCAL"
-
-    # Create symlink to DataFiles if needed
-    if [ ! -e "DataFiles" ]; then
-        ln -s ../DataFiles DataFiles
-    fi
-
-    # ============================================================
-    # Stage 2: Full Simulation with MPI
-    # ============================================================
-    echo ""
-    echo "Stage 2: Full simulation (MPI)..."
-
-    # Compile with MPI
-    if CC99='mpicc -std=c99 -D_GNU_SOURCE=1' qcc -I../../src-local \
-        -Wall -O2 -D_MPI=1 -disable-dimensions \
-        coalescenceBubble.c -o coalescenceBubble -lm 2>&1; then
-        echo "MPI compilation successful"
-    else
-        echo "ERROR: MPI compilation failed for case $CASE_NO" >&2
-        ((FAILED_CASES++)) || true
-        cd "$SCRIPT_DIR"
-        continue
-    fi
-
-    # Run simulation with mpirun (Hamilton uses mpirun, not srun)
-    echo "Running full simulation with ${MPI_TASKS} MPI tasks..."
-    echo "Command: mpirun -np ${MPI_TASKS} ./coalescenceBubble $OhOut $RhoIn $Rr $MAXlevel $tmax $zWall"
-    echo ""
-
-    if mpirun -np ${MPI_TASKS} ./coalescenceBubble $OhOut $RhoIn $Rr $MAXlevel $tmax $zWall; then
-        echo ""
-        echo "Case $CASE_NO completed successfully"
-        ((SUCCESSFUL_CASES++)) || true
-    else
-        EXIT_CODE=$?
-        echo ""
-        echo "ERROR: Case $CASE_NO failed with exit code $EXIT_CODE" >&2
-        ((FAILED_CASES++)) || true
-    fi
-
-    # Return to root directory
-    cd "$SCRIPT_DIR"
-    echo ""
 done
 
 # ============================================================
 # Final Summary
 # ============================================================
+echo ""
 echo "============================================="
-echo "Parameter Sweep Complete"
+echo "Stage 1 Complete"
 echo "============================================="
 echo "Job completed at: $(date)"
 echo "Total cases: $COMBINATION_COUNT"
 echo "Successful: $SUCCESSFUL_CASES"
 echo "Failed: $FAILED_CASES"
-echo "Skipped (no restart file): $SKIPPED_CASES"
-echo "Output location: simulationCases/"
-echo "============================================="
 echo ""
+echo "Restart files location: simulationCases/*/restart"
+echo ""
+if [ $SUCCESSFUL_CASES -gt 0 ]; then
+    echo "Next step: Submit Stage 2 with:"
+    echo "  sbatch runSweepHamilton.sbatch"
+fi
+echo "============================================="
 
-# Exit with error if any cases failed or were skipped
-if [ $FAILED_CASES -gt 0 ] || [ $SKIPPED_CASES -gt 0 ]; then
-    echo "WARNING: $FAILED_CASES case(s) failed, $SKIPPED_CASES case(s) skipped." >&2
-    echo "         Check logs for details." >&2
+if [ $FAILED_CASES -gt 0 ]; then
+    echo "WARNING: $FAILED_CASES case(s) failed. Check logs in simulationCases/*/stage1.log" >&2
     exit 1
 fi
 

--- a/runSweepSnellius-serial.sbatch
+++ b/runSweepSnellius-serial.sbatch
@@ -1,0 +1,433 @@
+#!/bin/bash
+#SBATCH --job-name=bubbleCoal-S1
+#SBATCH --nodes=1
+#SBATCH --ntasks=48
+#SBATCH --cpus-per-task=1
+#SBATCH --time=12:00:00
+#SBATCH --partition=genoa
+#SBATCH --mail-type=ALL
+#SBATCH --mail-user=vatsal.sanjay@comphy-lab.org
+#SBATCH --output=slurm-stage1-%j.out
+#SBATCH --error=slurm-stage1-%j.err
+
+# ============================================================
+# Bubble Coalescence - Stage 1 Serial Runner (Snellius)
+# ============================================================
+# This script runs Stage 1 (initialization) for all cases in parallel.
+# Each case runs on 1 core (serial, no OpenMP/MPI).
+# Up to 48 cases run simultaneously.
+#
+# Stage 1 generates restart files needed for Stage 2 (MPI simulation).
+#
+# AFTER RUNNING:
+# Submit Stage 2 with: sbatch runSweepSnellius.sbatch
+#
+# SBATCH Parameters to Customize:
+#   --ntasks: Number of concurrent cases (currently 48)
+#   --time: Wall time for all Stage 1 runs (currently 12 hours)
+#   --partition: Compute partition (currently genoa)
+#   --mail-user: Email for job notifications
+# ============================================================
+
+set -e  # Exit on error (but we'll handle case failures gracefully)
+
+# ============================================================
+# Configuration
+# ============================================================
+SCRIPT_DIR="${SLURM_SUBMIT_DIR}"
+SWEEP_FILE="${SCRIPT_DIR}/sweep.params"
+
+# Maximum concurrent jobs (matches SLURM allocation)
+MAX_CONCURRENT=${SLURM_NTASKS:-48}
+
+# Stage 1 tmax - short run to generate restart file
+STAGE1_TMAX="1e-2"
+
+# ============================================================
+# Print Job Information
+# ============================================================
+echo "============================================="
+echo "Bubble Coalescence - Stage 1 (Serial)"
+echo "============================================="
+echo "Job started at: $(date)"
+echo "Running on node: $(hostname)"
+echo "Working directory: $(pwd)"
+echo "Job ID: ${SLURM_JOB_ID}"
+echo "Max concurrent cases: ${MAX_CONCURRENT}"
+echo "Partition: ${SLURM_JOB_PARTITION}"
+echo ""
+echo "Mode: Stage 1 only (serial initialization)"
+echo "      Generates restart files for Stage 2"
+echo "      Each case runs on 1 core (no OpenMP/MPI)"
+echo ""
+
+# ============================================================
+# Load Required Modules (minimal for serial)
+# ============================================================
+echo "Loading modules..."
+module purge
+module load 2024
+module load GCC/13.3.0
+echo "Modules loaded (serial mode - GCC only, no MPI)"
+echo ""
+
+# ============================================================
+# Setup Basilisk Environment
+# ============================================================
+echo "Setting up Basilisk environment..."
+if [ -f "${SCRIPT_DIR}/.project_config" ]; then
+    source "${SCRIPT_DIR}/.project_config"
+    echo "Basilisk environment loaded from .project_config"
+    echo "BASILISK: $BASILISK"
+else
+    echo "ERROR: .project_config not found" >&2
+    exit 1
+fi
+echo ""
+
+# ============================================================
+# Validate Environment
+# ============================================================
+if [ -f "${SCRIPT_DIR}/src-local/parse_params.sh" ]; then
+    source "${SCRIPT_DIR}/src-local/parse_params.sh"
+else
+    echo "ERROR: src-local/parse_params.sh not found" >&2
+    exit 1
+fi
+
+if [ ! -f "$SWEEP_FILE" ]; then
+    echo "ERROR: Sweep file not found: $SWEEP_FILE" >&2
+    exit 1
+fi
+
+echo "Sweep file: $SWEEP_FILE"
+echo ""
+
+# ============================================================
+# Parse Sweep Configuration
+# ============================================================
+echo "Parsing sweep configuration..."
+
+source "$SWEEP_FILE"
+
+if [ -z "$BASE_CONFIG" ]; then
+    echo "ERROR: BASE_CONFIG not defined in sweep file" >&2
+    exit 1
+fi
+
+if [ -z "$CASE_START" ] || [ -z "$CASE_END" ]; then
+    echo "ERROR: CASE_START and CASE_END must be defined in sweep file" >&2
+    exit 1
+fi
+
+if [ "$CASE_START" -lt 1000 ] || [ "$CASE_START" -gt 9999 ]; then
+    echo "ERROR: CASE_START must be 4-digit (1000-9999), got: $CASE_START" >&2
+    exit 1
+fi
+
+if [ "$CASE_END" -lt "$CASE_START" ] || [ "$CASE_END" -gt 9999 ]; then
+    echo "ERROR: CASE_END must be >= CASE_START and <= 9999, got: $CASE_END" >&2
+    exit 1
+fi
+
+if [ ! -f "$BASE_CONFIG" ]; then
+    echo "ERROR: Base configuration file not found: $BASE_CONFIG" >&2
+    exit 1
+fi
+
+echo "Base configuration: $BASE_CONFIG"
+echo "Case number range: $CASE_START to $CASE_END"
+echo ""
+
+# ============================================================
+# Extract Sweep Variables
+# ============================================================
+SWEEP_VARS=()
+SWEEP_VALUES=()
+
+while IFS='=' read -r key value; do
+    [[ "$key" =~ ^[[:space:]]*# ]] && continue
+    [[ -z "$key" ]] && continue
+
+    if [[ "$key" =~ ^[[:space:]]*SWEEP_([^=]+) ]]; then
+        var_name="${BASH_REMATCH[1]}"
+        value=$(echo "$value" | sed 's/#.*//' | xargs)
+        SWEEP_VARS+=("$var_name")
+        SWEEP_VALUES+=("$value")
+    fi
+done < "$SWEEP_FILE"
+
+if [ ${#SWEEP_VARS[@]} -eq 0 ]; then
+    echo "ERROR: No SWEEP_* variables found in $SWEEP_FILE" >&2
+    exit 1
+fi
+
+echo "Sweep variables:"
+for i in "${!SWEEP_VARS[@]}"; do
+    echo "  ${SWEEP_VARS[$i]} = ${SWEEP_VALUES[$i]}"
+done
+echo ""
+
+# ============================================================
+# Generate Parameter Combinations
+# ============================================================
+echo "Generating parameter combinations..."
+
+TEMP_DIR="${SCRIPT_DIR}/.sweep_tmp_$$"
+mkdir -p "$TEMP_DIR" || {
+    echo "ERROR: Failed to create temp directory: $TEMP_DIR" >&2
+    exit 1
+}
+trap "rm -rf $TEMP_DIR" EXIT
+
+CASE_NUM=$CASE_START
+COMBINATION_COUNT=0
+CASE_FILES=()
+
+generate_combinations() {
+    local depth=$1
+    shift
+    local current_values=("$@")
+
+    if [ $depth -eq ${#SWEEP_VARS[@]} ]; then
+        local case_file="${TEMP_DIR}/case_$(printf "%04d" $CASE_NUM).params"
+        cp "$BASE_CONFIG" "$case_file"
+
+        if grep -q "^CaseNo=" "$case_file"; then
+            sed -i'.bak' "s|^CaseNo=.*|CaseNo=${CASE_NUM}|" "$case_file"
+        else
+            echo "CaseNo=${CASE_NUM}" >> "$case_file"
+        fi
+        rm -f "${case_file}.bak"
+
+        for i in "${!SWEEP_VARS[@]}"; do
+            local var="${SWEEP_VARS[$i]}"
+            local val="${current_values[$i]}"
+
+            if grep -q "^${var}=" "$case_file"; then
+                sed -i'.bak' "s|^${var}=.*|${var}=${val}|" "$case_file"
+            else
+                echo "${var}=${val}" >> "$case_file"
+            fi
+            rm -f "${case_file}.bak"
+        done
+
+        CASE_FILES+=("$case_file")
+        ((COMBINATION_COUNT++)) || true
+
+        echo "Case $CASE_NUM:"
+        for i in "${!SWEEP_VARS[@]}"; do
+            echo "  ${SWEEP_VARS[$i]} = ${current_values[$i]}"
+        done
+        echo ""
+
+        ((CASE_NUM++)) || true
+        return
+    fi
+
+    local values="${SWEEP_VALUES[$depth]}"
+    IFS=',' read -ra value_array <<< "$values"
+
+    for val in "${value_array[@]}"; do
+        val=$(echo "$val" | xargs)
+        generate_combinations $((depth + 1)) ${current_values[@]+"${current_values[@]}"} "$val"
+    done
+}
+
+generate_combinations 0
+
+echo "Generated $COMBINATION_COUNT parameter combinations"
+
+EXPECTED_COUNT=$((CASE_END - CASE_START + 1))
+if [ $COMBINATION_COUNT -ne $EXPECTED_COUNT ]; then
+    echo "WARNING: Generated $COMBINATION_COUNT combinations, but CASE_END suggests $EXPECTED_COUNT" >&2
+fi
+
+if [ $COMBINATION_COUNT -gt $EXPECTED_COUNT ]; then
+    echo "ERROR: Too many combinations ($COMBINATION_COUNT) for range $CASE_START-$CASE_END" >&2
+    exit 1
+fi
+
+echo ""
+
+# ============================================================
+# Prepare Status Tracking
+# ============================================================
+STATUS_DIR="${TEMP_DIR}/status"
+mkdir -p "$STATUS_DIR"
+
+# ============================================================
+# Function to Run Single Case (Stage 1)
+# ============================================================
+run_stage1_case() {
+    local param_file=$1
+    local status_dir=$2
+    local script_dir=$3
+    local stage1_tmax=$4
+
+    # Source parameter parsing in subshell
+    source "${script_dir}/src-local/parse_params.sh"
+
+    parse_param_file "$param_file"
+    local CASE_NO=$(get_param "CaseNo")
+    local OhOut=$(get_param "OhOut" "1e-2")
+    local RhoIn=$(get_param "RhoIn" "1e-3")
+    local Rr=$(get_param "Rr" "1.0")
+    local MAXlevel=$(get_param "MAXlevel" "10")
+    local zWall=$(get_param "zWall" "0.01")
+
+    if [ -z "$CASE_NO" ]; then
+        echo "FAILED" > "${status_dir}/${CASE_NO:-unknown}"
+        return 1
+    fi
+
+    local CASE_DIR="${script_dir}/simulationCases/${CASE_NO}"
+    local LOG_FILE="${CASE_DIR}/stage1.log"
+
+    {
+        echo "========================================="
+        echo "Case $CASE_NO - Stage 1 ($(date))"
+        echo "========================================="
+        echo "Parameters: OhOut=$OhOut, RhoIn=$RhoIn, Rr=$Rr"
+        echo "            MAXlevel=$MAXlevel, tmax=$stage1_tmax, zWall=$zWall"
+
+        # Create case directory
+        mkdir -p "$CASE_DIR"
+        cd "$CASE_DIR"
+
+        # Copy source file
+        local SRC_FILE_ORIG="${script_dir}/simulationCases/coalescenceBubble.c"
+        if [ ! -f "$SRC_FILE_ORIG" ]; then
+            echo "ERROR: Source file not found"
+            echo "FAILED" > "${status_dir}/${CASE_NO}"
+            return 1
+        fi
+        cp "$SRC_FILE_ORIG" "coalescenceBubble.c"
+
+        # Create symlink to DataFiles
+        if [ ! -e "DataFiles" ]; then
+            ln -s ../DataFiles DataFiles
+        fi
+
+        # Compile SERIAL (no OpenMP, no MPI)
+        echo "Compiling (serial)..."
+        if ! qcc -I../../src-local -Wall -O2 -disable-dimensions \
+            coalescenceBubble.c -o coalescenceBubble -lm 2>&1; then
+            echo "ERROR: Compilation failed"
+            echo "FAILED" > "${status_dir}/${CASE_NO}"
+            return 1
+        fi
+        echo "Compilation successful"
+
+        # Run Stage 1 with small tmax
+        echo "Running Stage 1 (tmax=$stage1_tmax)..."
+        if ./coalescenceBubble $OhOut $RhoIn $Rr $MAXlevel $stage1_tmax $zWall; then
+            echo "Stage 1 completed"
+
+            # Verify restart file was created
+            if [ -f "restart" ]; then
+                echo "Restart file created successfully"
+                echo "SUCCESS" > "${status_dir}/${CASE_NO}"
+            else
+                echo "WARNING: restart file not found after Stage 1"
+                echo "FAILED" > "${status_dir}/${CASE_NO}"
+                return 1
+            fi
+        else
+            echo "ERROR: Stage 1 failed"
+            echo "FAILED" > "${status_dir}/${CASE_NO}"
+            return 1
+        fi
+
+        echo "Case $CASE_NO Stage 1 complete"
+    } > "$LOG_FILE" 2>&1
+
+    return 0
+}
+
+export -f run_stage1_case
+
+# ============================================================
+# Run All Cases in Parallel (Stage 1)
+# ============================================================
+echo "============================================="
+echo "Running $COMBINATION_COUNT Cases (Stage 1)"
+echo "============================================="
+echo "Max concurrent: ${MAX_CONCURRENT}"
+echo "Each case: serial execution, tmax=${STAGE1_TMAX}"
+echo ""
+
+RUNNING_JOBS=0
+PIDS=()
+
+for param_file in "${CASE_FILES[@]}"; do
+    # Wait if we've hit the concurrency limit
+    while [ $RUNNING_JOBS -ge $MAX_CONCURRENT ]; do
+        # Wait for any background job to finish
+        wait -n 2>/dev/null || true
+        ((RUNNING_JOBS--)) || true
+    done
+
+    # Launch case in background
+    run_stage1_case "$param_file" "$STATUS_DIR" "$SCRIPT_DIR" "$STAGE1_TMAX" &
+    PIDS+=($!)
+    ((RUNNING_JOBS++)) || true
+
+    # Extract case number for logging
+    parse_param_file "$param_file"
+    CASE_NO=$(get_param "CaseNo")
+    echo "Launched case $CASE_NO (PID: ${PIDS[-1]}, running: $RUNNING_JOBS)"
+done
+
+echo ""
+echo "All cases launched, waiting for completion..."
+echo ""
+
+# Wait for all remaining jobs
+wait
+
+# ============================================================
+# Collect Results
+# ============================================================
+SUCCESSFUL_CASES=0
+FAILED_CASES=0
+
+for status_file in "${STATUS_DIR}"/*; do
+    if [ -f "$status_file" ]; then
+        status=$(cat "$status_file")
+        case_no=$(basename "$status_file")
+        if [ "$status" = "SUCCESS" ]; then
+            ((SUCCESSFUL_CASES++)) || true
+        else
+            ((FAILED_CASES++)) || true
+            echo "FAILED: Case $case_no"
+        fi
+    fi
+done
+
+# ============================================================
+# Final Summary
+# ============================================================
+echo ""
+echo "============================================="
+echo "Stage 1 Complete"
+echo "============================================="
+echo "Job completed at: $(date)"
+echo "Total cases: $COMBINATION_COUNT"
+echo "Successful: $SUCCESSFUL_CASES"
+echo "Failed: $FAILED_CASES"
+echo ""
+echo "Restart files location: simulationCases/*/restart"
+echo ""
+if [ $SUCCESSFUL_CASES -gt 0 ]; then
+    echo "Next step: Submit Stage 2 with:"
+    echo "  sbatch runSweepSnellius.sbatch"
+fi
+echo "============================================="
+
+if [ $FAILED_CASES -gt 0 ]; then
+    echo "WARNING: $FAILED_CASES case(s) failed. Check logs in simulationCases/*/stage1.log" >&2
+    exit 1
+fi
+
+exit 0


### PR DESCRIPTION
## Summary
- Add HPC sbatch scripts for running Stage 1 (restart file generation) in parallel
- Enable batch initialization of up to 48 cases simultaneously on Hamilton and Snellius
- Each case runs serially (no OpenMP/MPI) on a single core

## Changes Made
- Add `runSweepHamilton-serial.sbatch` for Durham Hamilton HPC
- Add `runSweepSnellius-serial.sbatch` for Snellius HPC
- Update email in `runSweepHamilton.sbatch` to correct address

## How It Works
The new scripts complement the existing Stage 2 MPI scripts:

```bash
# Step 1: Run Stage 1 (generates restart files)
sbatch runSweepHamilton-serial.sbatch

# Step 2: Run Stage 2 (full MPI simulation)
sbatch runSweepHamilton.sbatch
```

Key features:
- Runs `tmax=1e-2` to generate restart files quickly
- Background bash jobs with concurrency control (max 48)
- Per-case logging to `simulationCases/<CaseNo>/stage1.log`
- Status tracking and summary at completion

## Testing
- Scripts follow same parameter sweep logic as existing Stage 2 scripts
- Verified SLURM directives match cluster requirements